### PR TITLE
Add a way to install Python modules without needing elevated permissions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -91,16 +91,11 @@ class SIDPreferences(bpy.types.AddonPreferences):
                 col.label(text="Check Blender's System Console or your terminal for errors.")
                 col.separator()
 
-            col.label(text="Blender must either:")
-            col.label(
-                text="    * be run as an Administrator, or")
-            col.label(
-                text="    * you must have write permissions to Blender's " \
-                    "installed location.")
             col = layout.column(align=True)
             col.label(
                 text="Installation may take a few minutes, and Blender will " \
                     "stop responding during this time.")
+            col.label(text="If the Install Dependencies button is still visible after this process completes, please restart Blender.")
 
             col.operator("initialise.sfr_install_dependencies")
         else:

--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,14 @@
+# To make sure installed modules work
+import os, sys
+module_path = os.path.join(os.path.dirname(__file__), "python_modules")
+sys.path.append(module_path) # Add a module path for this specific addon
+
 import bpy
 from bpy.props import (
     PointerProperty,
     BoolProperty,
     IntProperty
 )
-import os, sys
 from .install_deps import (
     dependencies,
     SFR_OT_CheckDependencies,
@@ -141,10 +145,7 @@ classes = (
 )
 
 
-def register():
-    module_path = os.path.join(os.path.dirname(__file__), "python_modules")
-    sys.path.append(module_path) # Add a module path for this specific addon
-
+def register(): 
     # addon updater code and configurations
     # in case of broken version, try to register the updater first
     # so that users can revert back to a working version

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,7 @@ from bpy.props import (
     BoolProperty,
     IntProperty
 )
+import os, sys
 from .install_deps import (
     dependencies,
     SFR_OT_CheckDependencies,
@@ -141,6 +142,9 @@ classes = (
 
 
 def register():
+    module_path = os.path.join(os.path.dirname(__file__), "python_modules")
+    sys.path.append(module_path) # Add a module path for this specific addon
+
     # addon updater code and configurations
     # in case of broken version, try to register the updater first
     # so that users can revert back to a working version

--- a/install_deps.py
+++ b/install_deps.py
@@ -93,8 +93,7 @@ def install_module(module_name, package_name=None):
     environ_copy["PYTHONNOUSERSITE"] = "1"
 
     subprocess.run([sys.executable, "-m", "pip", "install", "--target=", module_path, package_name], check=True, env=environ_copy)
-    sys.path.append(module_path) # Add a module path for this specific addon
-
+    
 
 class Dependencies_check_singleton(object):
     def __init__(self):

--- a/install_deps.py
+++ b/install_deps.py
@@ -93,7 +93,6 @@ def install_module(module_name, package_name=None):
     environ_copy["PYTHONNOUSERSITE"] = "1"
 
     subprocess.run([sys.executable, "-m", "pip", "install", "--target=", module_path, package_name], check=True, env=environ_copy)
-    
 
 class Dependencies_check_singleton(object):
     def __init__(self):

--- a/install_deps.py
+++ b/install_deps.py
@@ -93,7 +93,7 @@ def install_module(module_name, package_name=None):
     environ_copy["PYTHONNOUSERSITE"] = "1"
 
     subprocess.run([sys.executable, "-m", "pip", "install", "--target=", module_path, package_name], check=True, env=environ_copy)
-    sys.path.append(module_path)
+    sys.path.append(module_path) # Add a module path for this specific addon
 
 
 class Dependencies_check_singleton(object):

--- a/install_deps.py
+++ b/install_deps.py
@@ -90,9 +90,9 @@ def install_module(module_name, package_name=None):
 
     # Create a copy of the environment variables and modify them for the subprocess call
     environ_copy = dict(os.environ)
-    environ_copy["PYTHONNOUSERSITE"] = "1"
+    #environ_copy["PYTHONNOUSERSITE"] = "1"
 
-    subprocess.run([sys.executable, "-m", "pip", "install", "--target=", module_path, package_name], check=True, env=environ_copy)
+    subprocess.run([sys.executable, "-m", "pip", "install", package_name, "-t", module_path], check=True, env=environ_copy)
 
 class Dependencies_check_singleton(object):
     def __init__(self):

--- a/install_deps.py
+++ b/install_deps.py
@@ -75,6 +75,11 @@ def install_module(module_name, package_name=None):
 
     if package_name is None:
         package_name = module_name
+    
+    # Create a folder to install python modules
+    module_path = os.path.join(os.path.dirname(__file__), "python_modules")
+    if not os.path.exists(module_path):
+        os.mkdir(module_path)
 
     # Blender disables the loading of user site-packages by default. However, pip will still check them to determine
     # if a dependency is already installed. This can cause problems if the packages is installed in the user
@@ -87,7 +92,8 @@ def install_module(module_name, package_name=None):
     environ_copy = dict(os.environ)
     environ_copy["PYTHONNOUSERSITE"] = "1"
 
-    subprocess.run([sys.executable, "-m", "pip", "install", package_name], check=True, env=environ_copy)
+    subprocess.run([sys.executable, "-m", "pip", "install", "--target=", module_path, package_name], check=True, env=environ_copy)
+    sys.path.append(module_path)
 
 
 class Dependencies_check_singleton(object):


### PR DESCRIPTION
Basically what the title says. By removing the need for elevated permissions, it allows supporting versions of Blender with read only paths, like Microsoft store and Snap. It also allows user who may not have elevated permissions to use SFR

I haven't yet tested this, so there's likely going to be bugs, but tell me what y'all think